### PR TITLE
castor common: overlay: Add lid cover power control

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -92,4 +92,9 @@
     <!-- Whether device supports double tap to wake -->
     <bool name="config_supportDoubleTapWake">true</bool>
 
+    <!-- Indicate whether closing the lid causes the device to go to sleep and opening
+         it causes the device to wake up.
+         The default is false. -->
+    <bool name="config_lidControlsSleep">true</bool>
+
 </resources>


### PR DESCRIPTION
Its needed to get cover support 

This overlay entry indicates whether closing the lid
causes the device to go to sleep and opening it causes
the device to wake up.

Kernel driver is fixed for it here:
https://github.com/sonyxperiadev/kernel/commit/8b6dc10acf3a0e7545d84427d8022c365d8ea03d
